### PR TITLE
fix(query-generator): prevent name clash in subquery where-clause on self-reference

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1879,6 +1879,11 @@ class QueryGenerator {
     topInclude.association = undefined;
 
     if (topInclude.through && Object(topInclude.through.model) === topInclude.through.model) {
+      // Make sure the top parent name in the where-clause doesn't clash with any included models
+      if (topAssociation.toTarget !== undefined && topParent.model.name === topAssociation.toTarget.as) {
+        topAssociation.toTarget.as = `${topAssociation.toTarget.as}_${uuidv4()}`;
+      }
+
       query = this.selectQuery(topInclude.through.model.getTableName(), {
         attributes: [topInclude.through.model.primaryKeyField],
         include: Model._validateIncludedElements({


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

In the case of a limit on a self-reference with through-table, a subquery is generated with a subquery filter.The where-clause tries to reference the first instance (from) of the tabel but actually references the second instance (to) used in the join of the through-table as both tables are given the same default alias.
This fix checks for this case and gives the second table a randomized unique alias preventing confusion in the where-clause.